### PR TITLE
add google sign in

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -31,6 +31,9 @@ export const env = createEnv({
     // Add ` on ID and SECRET if you want to make sure they're not empty
     DISCORD_CLIENT_ID: z.string(),
     DISCORD_CLIENT_SECRET: z.string(),
+
+    GOOGLE_CLIENT_ID: z.string(), 
+    GOOGLE_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -53,6 +56,8 @@ export const env = createEnv({
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,8 @@ import Head from "next/head";
 import Link from "next/link";
 
 import { api } from "~/utils/api";
+import { GoogleOAuthProvider } from '@react-oauth/google';
+
 
 export default function Home() {
   const hello = api.post.hello.useQuery({ text: "from tRPC" });

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -6,6 +6,8 @@ import {
   type NextAuthOptions,
 } from "next-auth";
 import DiscordProvider from "next-auth/providers/discord";
+import GoogleProvider from "next-auth/providers/google";
+
 
 import { env } from "~/env.mjs";
 import { db } from "~/server/db";
@@ -51,6 +53,10 @@ export const authOptions: NextAuthOptions = {
     DiscordProvider({
       clientId: env.DISCORD_CLIENT_ID,
       clientSecret: env.DISCORD_CLIENT_SECRET,
+    }),
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
     }),
     /**
      * ...add more providers here.


### PR DESCRIPTION
Add Google sign in following this [guide](https://dev.to/hqasmei/setting-up-the-google-provider-in-t3-stack-1kjf)
<img width="422" alt="image" src="https://github.com/teamsela/sela-web/assets/26335650/74207826-8d6d-45ed-844f-2cc4431e0f7d">

This part is still incomplete as Step 5, 6 from the above guide needs backend to finish, also checkout step 4 for credential setup. Code from step 4 is complete, but each developer needs to add credential to `.env` locally